### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,5 +4,7 @@
 "dependencies": {
 "left-pad": "1.1.0"
 },
-"renovate": {}
+"renovate": {
+  "renovateFork": true
+}
 }


### PR DESCRIPTION
Renovate by default ignores forked repositories, this setting enables an override